### PR TITLE
Fixing compile error BinaryHeap uses from now not from_vec.

### DIFF
--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -48,7 +48,7 @@ impl<T: ToString+Clone> HashRing<T> {
 			self.sorted_keys.push(key.clone());
 		}
 
-		self.sorted_keys = BinaryHeap::from_vec(self.sorted_keys.clone()).into_sorted_vec();
+		self.sorted_keys = BinaryHeap::from(self.sorted_keys.clone()).into_sorted_vec();
 	}
 
 	/// Deletes a node from the hash ring

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(collections)]
 #![crate_name = "hash_ring"]
 #![crate_type = "lib"]
 


### PR DESCRIPTION
I was checking out your library and I fixed a compile error.  It now compiles against stable.
