### PR TITLE
Replace md5 with xxhash algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ travis-ci = { repository = "mattnenterprise/rust-hash-ring" }
 coveralls = { repository = "mattnenterprise/rust-hash-ring", branch = "master", service = "github" }
 
 [dependencies]
-md5 = "0.3.5"
+fasthash = "0.3"

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -1,4 +1,5 @@
-use md5;
+use fasthash::{XXHasher};
+use std::hash::{Hash, Hasher};
 use std::collections::HashMap;
 use std::collections::BinaryHeap;
 
@@ -89,9 +90,15 @@ impl<T: ToString + Clone> HashRing<T> {
 
     /// Generates a key from a string value
     fn gen_key(&mut self, key: String) -> String {
-        let digest = md5::compute(key);
+        let digest = hash(&key);
         format!("{:x}", digest)
     }
+}
+
+fn hash<H: Hash>(t: &H) -> u64 {
+    let mut s: XXHasher = Default::default();
+    t.hash(&mut s);
+    s.finish()
 }
 
 #[cfg(test)]
@@ -125,14 +132,14 @@ mod test {
 
         let mut hash_ring: HashRing<NodeInfo> = HashRing::new(nodes, 10);
 
-        assert_eq!(Some(&node(15329)), hash_ring.get_node("hello".to_string()));
-        assert_eq!(Some(&node(15326)), hash_ring.get_node("dude".to_string()));
+        assert_eq!(Some(&node(15325)), hash_ring.get_node("hello".to_string()));
+        assert_eq!(Some(&node(15329)), hash_ring.get_node("dude".to_string()));
 
         hash_ring.remove_node(&node(15329));
-        assert_eq!(Some(&node(15327)), hash_ring.get_node("hello".to_string()));
+        assert_eq!(Some(&node(15325)), hash_ring.get_node("hello".to_string()));
 
         hash_ring.add_node(&node(15329));
-        assert_eq!(Some(&node(15329)), hash_ring.get_node("hello".to_string()));
+        assert_eq!(Some(&node(15329)), hash_ring.get_node("dude".to_string()));
     }
 
     #[derive(Clone)]
@@ -180,13 +187,13 @@ mod test {
         let mut hash_ring: HashRing<CustomNodeInfo> = HashRing::new(nodes, 10);
 
         assert_eq!(
-            Some("localhost:15329".to_string()),
+            Some("localhost:15325".to_string()),
             hash_ring.get_node("hello".to_string()).map(
                 |x| x.to_string(),
             )
         );
         assert_eq!(
-            Some("localhost:15326".to_string()),
+            Some("localhost:15329".to_string()),
             hash_ring.get_node("dude".to_string()).map(
                 |x| x.to_string(),
             )
@@ -197,7 +204,7 @@ mod test {
             port: 15329,
         });
         assert_eq!(
-            Some("localhost:15327".to_string()),
+            Some("localhost:15325".to_string()),
             hash_ring.get_node("hello".to_string()).map(
                 |x| x.to_string(),
             )
@@ -208,7 +215,7 @@ mod test {
             port: 15329,
         });
         assert_eq!(
-            Some("localhost:15329".to_string()),
+            Some("localhost:15325".to_string()),
             hash_ring.get_node("hello".to_string()).map(
                 |x| x.to_string(),
             )

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -55,17 +55,19 @@ impl<T: ToString + Clone> HashRing<T> {
 
     /// Deletes a node from the hash ring
     pub fn remove_node(&mut self, node: &T) {
-        for i in 0..self.replicas {
-            let key = self.gen_key(format!("{}:{}", node.to_string(), i));
-            self.ring.remove(&key);
-            let mut index = 0;
-            for j in 0..self.sorted_keys.len() {
-                if self.sorted_keys[j] == key {
-                    index = j;
-                    break;
+        if self.sorted_keys.len() > 0 {
+            for i in 0..self.replicas {
+                let key = self.gen_key(format!("{}:{}", node.to_string(), i));
+                self.ring.remove(&key);
+                let mut index = 0;
+                for j in 0..self.sorted_keys.len() {
+                    if self.sorted_keys[j] == key {
+                        index = j;
+                        break;
+                    }
                 }
+                self.sorted_keys.remove(index);
             }
-            self.sorted_keys.remove(index);
         }
     }
 

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -18,6 +18,7 @@ impl ToString for NodeInfo {
 }
 
 /// HashRing
+#[derive(Debug, Clone)]
 pub struct HashRing<T> {
     replicas: isize,
     ring: HashMap<String, T>,

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -55,17 +55,17 @@ impl<T: ToString + Clone> HashRing<T> {
 
     /// Deletes a node from the hash ring
     pub fn remove_node(&mut self, node: &T) {
-        if self.sorted_keys.len() > 0 {
-            for i in 0..self.replicas {
-                let key = self.gen_key(format!("{}:{}", node.to_string(), i));
-                self.ring.remove(&key);
-                let mut index = 0;
-                for j in 0..self.sorted_keys.len() {
-                    if self.sorted_keys[j] == key {
-                        index = j;
-                        break;
-                    }
+        for i in 0..self.replicas {
+            let key = self.gen_key(format!("{}:{}", node.to_string(), i));
+            self.ring.remove(&key);
+            let mut index = 0;
+            for j in 0..self.sorted_keys.len() {
+                if self.sorted_keys[j] == key {
+                    index = j;
+                    break;
                 }
+            }
+            if self.sorted_keys.len() > index{
                 self.sorted_keys.remove(index);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "hash_ring"]
 #![crate_type = "lib"]
 
-extern crate md5;
+extern crate fasthash;
 mod hash_ring;
 pub use hash_ring::NodeInfo;
 pub use hash_ring::HashRing;


### PR DESCRIPTION
Great library! In case there is any interest, in my fork I replaced the md5 algorithm with xxhash solely for performance reasons.  xxhash isn't a Crypto hash but I figured that isn't a concern.  

This PR:
- replaces the md5 crate dependency with fasthash

- adds a new xx hash function to replaces md5::compute

- updates unit tests
