### PR TITLE
Change &mut self to &self

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ travis-ci = { repository = "mattnenterprise/rust-hash-ring" }
 coveralls = { repository = "mattnenterprise/rust-hash-ring", branch = "master", service = "github" }
 
 [dependencies]
-md5 = "0.3.5"
+twox-hash = "1.5.0"

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -1,4 +1,5 @@
-use md5;
+use twox_hash::XxHash64;
+use std::hash::{Hasher};
 use std::collections::HashMap;
 use std::collections::BinaryHeap;
 
@@ -89,9 +90,16 @@ impl<T: ToString + Clone> HashRing<T> {
 
     /// Generates a key from a string value
     fn gen_key(&self, key: String) -> String {
-        let digest = md5::compute(key);
+        let digest = hash(key.as_bytes());
         format!("{:x}", digest)
     }
+}
+
+
+fn hash(t: &[u8]) -> u64 {
+    let mut hasher = XxHash64::with_seed(0);
+    hasher.write(t);
+    hasher.finish()
 }
 
 #[cfg(test)]
@@ -125,14 +133,14 @@ mod test {
 
         let mut hash_ring: HashRing<NodeInfo> = HashRing::new(nodes, 10);
 
-        assert_eq!(Some(&node(15329)), hash_ring.get_node("hello".to_string()));
-        assert_eq!(Some(&node(15326)), hash_ring.get_node("dude".to_string()));
+        assert_eq!(Some(&node(15326)), hash_ring.get_node("hello".to_string()));
+        assert_eq!(Some(&node(15327)), hash_ring.get_node("dude".to_string()));
 
         hash_ring.remove_node(&node(15329));
-        assert_eq!(Some(&node(15327)), hash_ring.get_node("hello".to_string()));
+        assert_eq!(Some(&node(15326)), hash_ring.get_node("hello".to_string()));
 
         hash_ring.add_node(&node(15329));
-        assert_eq!(Some(&node(15329)), hash_ring.get_node("hello".to_string()));
+        assert_eq!(Some(&node(15327)), hash_ring.get_node("dude".to_string()));
     }
 
     #[derive(Clone)]
@@ -180,13 +188,13 @@ mod test {
         let mut hash_ring: HashRing<CustomNodeInfo> = HashRing::new(nodes, 10);
 
         assert_eq!(
-            Some("localhost:15329".to_string()),
+            Some("localhost:15326".to_string()),
             hash_ring.get_node("hello".to_string()).map(
                 |x| x.to_string(),
             )
         );
         assert_eq!(
-            Some("localhost:15326".to_string()),
+            Some("localhost:15327".to_string()),
             hash_ring.get_node("dude".to_string()).map(
                 |x| x.to_string(),
             )
@@ -197,7 +205,7 @@ mod test {
             port: 15329,
         });
         assert_eq!(
-            Some("localhost:15327".to_string()),
+            Some("localhost:15326".to_string()),
             hash_ring.get_node("hello".to_string()).map(
                 |x| x.to_string(),
             )
@@ -208,7 +216,7 @@ mod test {
             port: 15329,
         });
         assert_eq!(
-            Some("localhost:15329".to_string()),
+            Some("localhost:15326".to_string()),
             hash_ring.get_node("hello".to_string()).map(
                 |x| x.to_string(),
             )

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -56,6 +56,10 @@ impl<T: ToString + Clone> HashRing<T> {
     pub fn remove_node(&mut self, node: &T) {
         for i in 0..self.replicas {
             let key = self.gen_key(format!("{}:{}", node.to_string(), i));
+            if !self.ring.contains_key(&key) {
+                break;
+            }
+
             self.ring.remove(&key);
             let mut index = 0;
             for j in 0..self.sorted_keys.len() {

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -68,7 +68,7 @@ impl<T: ToString + Clone> HashRing<T> {
     }
 
     /// Gets the node a specific key belongs to
-    pub fn get_node(&mut self, key: String) -> Option<&T> {
+    pub fn get_node(&self, key: String) -> Option<&T> {
         if self.sorted_keys.is_empty() {
             return None;
         }
@@ -88,7 +88,7 @@ impl<T: ToString + Clone> HashRing<T> {
     }
 
     /// Generates a key from a string value
-    fn gen_key(&mut self, key: String) -> String {
+    fn gen_key(&self, key: String) -> String {
         let digest = md5::compute(key);
         format!("{:x}", digest)
     }

--- a/src/hash_ring.rs
+++ b/src/hash_ring.rs
@@ -64,7 +64,10 @@ impl<T: ToString + Clone> HashRing<T> {
                     break;
                 }
             }
-            self.sorted_keys.remove(index);
+
+            if !self.sorted_keys.is_empty() {
+                self.sorted_keys.remove(index);
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![crate_name = "hash_ring"]
 #![crate_type = "lib"]
 
-extern crate md5;
+extern crate twox_hash;
 mod hash_ring;
 pub use hash_ring::NodeInfo;
 pub use hash_ring::HashRing;


### PR DESCRIPTION
In order to use `get_node` with `RwLock` changing `&mut self` to `&self` is needed.
Mutable borrowing is not allowed with `RwLock` in case of reads.